### PR TITLE
use VERSION_NUM instead of VERSION to get rid of leading 'v'

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -1,4 +1,4 @@
-version = "%%VERSION%%"
+version = "%%VERSION_NUM%%"
 description = "Base64 encoding library"
 requires = "bytes"
 archive(byte) = "b64.cma"


### PR DESCRIPTION
partially fixes #10