### PR TITLE
Add `Base64.encode_string` that doesn't raise or return an error.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
+### v3.1.0
+
+* Add `Base64.encode_string` that doesn't raise or return an error.
+  This makes it easier to port pre-3.0 code to the new interface (@avsm)
+
 ### v3.0.0 (2018-01-21)
 
-* Implemenation of Base64 according to RFC 2045 (available on base64.rfc2045)
+* Implementation of Base64 according to RFC 2045 (available on base64.rfc2045)
 * New implementation of Base64 according to RFC 4648 from nocrypto's implementation
 * Fix bad access with `String.iter` on the old implementation of Base64 (@dinosaure, #23)
 * Check isomorphism between `encode` & `decode` function (@hannesm, @dinosaure, #20)

--- a/src/base64.ml
+++ b/src/base64.ml
@@ -128,6 +128,11 @@ let encode ?(pad = true) ?(alphabet = default_alphabet) ?off ?len input =
   | Ok (res, off, len) -> Ok (String.sub res off len)
   | Error _ as err -> err
 
+let encode_string ?pad ?alphabet input =
+  match encode ?pad ?alphabet input with
+  | Ok res -> res
+  | Error _ -> assert false
+
 let encode_sub ?(pad = true) ?(alphabet = default_alphabet) ?off ?len input =
   encode_sub pad alphabet ?off ?len input
 

--- a/src/base64.mli
+++ b/src/base64.mli
@@ -78,6 +78,11 @@ val encode : ?pad:bool -> ?alphabet:alphabet -> ?off:int -> ?len:int -> string -
 
     [encode] fails when [off] and [len] do not designate a valid range of [s]. *)
 
+val encode_string : ?pad:bool -> ?alphabet:alphabet -> string -> string
+(** [encode_string s] encodes the string [s] into base64. If [pad] is false, no
+    trailing padding is added. [pad] defaults to [true], and [alphabet] to
+    {!default_alphabet}. *)
+
 val encode_sub : ?pad:bool -> ?alphabet:alphabet -> ?off:int -> ?len:int -> string -> (sub, [ `Msg of string]) result
 (** Same as {!encode} but return a {!sub}-string instead a plain result. By this
     way, we ensure to allocate only one time result. *)


### PR DESCRIPTION
This makes it easier to port pre-3.0 code to the new interface