### PR TITLE
Revert "introduce conflicts with extlib, both define the base64 module"

### DIFF
--- a/base64.opam
+++ b/base64.opam
@@ -27,7 +27,3 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
-conflicts: [
-  "extlib"
-  "extlib-compat"
-]


### PR DESCRIPTION
This reverts commit 49ed113cb2889e682fb3af5b7938587f12ddace5.

as mentioned by in https://github.com/ocaml/opam-repository/pull/13552 this should be not an opam conflict