### PR TITLE
 Make whitespace handling more permissive

### DIFF
--- a/src/base64_rfc2045.ml
+++ b/src/base64_rfc2045.ml
@@ -120,8 +120,6 @@ let ret k v byte_count decoder =
   if decoder.limit_count > 78 then dangerous decoder true ;
   decoder.pp decoder v
 
-[@@@warning "-32"]
-
 type flush_and_malformed = [`Flush of state | `Malformed of string]
 
 let padding {size; _} padding =


### PR DESCRIPTION
While attempting to update [[Async_smtp]](https://www.github.com/janestreet/async_smtp) to use this library we saw issues when parsing emails with non compliant base64 input.

This makes [[Base64_rfc2045]](https://github.com/mirage/ocaml-base64/blob/master/src/base64_rfc2045.mli) ignore any combination of white space characters, including non standard line breaks.

This may also help address #6.