### PR TITLE
[Base64_rfc2045.decode] should always progresses

### DIFF
--- a/src/base64_rfc2045.ml
+++ b/src/base64_rfc2045.ml
@@ -143,6 +143,10 @@ let t_flush {quantum; size; buffer} =
       `Flush {quantum; size; buffer= Bytes.sub buffer 0 2}
   | _ -> assert false (* this branch is impossible, size can only ever be in the range [0..3]. *)
 
+let wrong_padding decoder =
+  let k _ = `End in
+  decoder.k <- k ; `Wrong_padding
+
 let rec t_decode_base64 chr decoder =
   if decoder.padding = 0 then
     let rec go pos = function
@@ -202,7 +206,7 @@ and decode_base64 decoder =
     if rem < 0 then
       ret
         (fun decoder ->
-          if padding decoder.s decoder.padding then `End else `Wrong_padding )
+          if padding decoder.s decoder.padding then `End else wrong_padding decoder )
         (t_flush decoder.s) 0 decoder
     else refill decode_base64 decoder
   else

--- a/src/base64_rfc2045.ml
+++ b/src/base64_rfc2045.ml
@@ -141,7 +141,7 @@ let t_flush {quantum; size; buffer} =
       unsafe_set_chr buffer 0 (unsafe_chr ((quantum lsr 8) land 255)) ;
       unsafe_set_chr buffer 1 (unsafe_chr (quantum land 255)) ;
       `Flush {quantum; size; buffer= Bytes.sub buffer 0 2}
-  | _ -> assert false
+  | _ -> assert false (* this branch is impossible, size can only ever be in the range [0..3]. *)
 
 let rec t_decode_base64 chr decoder =
   if decoder.padding = 0 then

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base64 rresult alcotest bos))
+ (libraries base64 base64.rfc2045 rresult alcotest bos))
 
 (alias
  (name runtest)


### PR DESCRIPTION
Currently [Base64_rfc2045.decode] will get stuck on many unexpected characters, e.g. a single "\r".
This pull request fixes this to **always** make forward progress and to only discard 1 character, this allows graceful recovery for most malformed inputs (similar to ``Core.Base64``).

This pull request should make #33 unecessary, as white-space can be ignored by the client by ignoring `` `Malformed str `` where `` str `` consists of white-space only.

It's should be possible to make the parser stricter now and to enforce the encode/decode isomorphism while supporting more permissive use cases (e.g. parsing email bodies robustly)

Finally, the changes the the CRLF handling code where needed to make positive progress around lone "\r" characters (the original version was hard to reason about and fix to not also skip the character after "\r")