### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/base64.opam
+++ b/base64.opam
@@ -17,7 +17,7 @@ representation.  It is specified in RFC 4648.
 depends: [
   "ocaml" {>="4.03.0"}
   "base-bytes"
-  "dune" {build & >= "1.0.1"}
+  "dune" {>= "1.0.1"}
   "bos" {with-test}
   "rresult" {with-test}
   "alcotest" {with-test}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.