### PR TITLE
Fix support for x-compilation

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,8 +6,8 @@
 
 (rule
  (targets unsafe.ml)
- (deps (:config ../config/config.exe) unsafe_pre407.ml unsafe_stable.ml)
- (action (run %{config})))
+ (deps unsafe_pre407.ml unsafe_stable.ml)
+ (action (run ../config/config.exe)))
 
 (library
  (name base64_rfc2045)


### PR DESCRIPTION
Specifying a dependency as `(dep x)` will make `dune` trying to compile
`x` in the current workspace context. It already knows that `(run ./x)` needs
to be run on the host context, so that's enough to make that work.