### PR TITLE
Select `unsafe.ml` with just dune rules

### DIFF
--- a/base64.opam
+++ b/base64.opam
@@ -17,7 +17,6 @@ representation.  It is specified in RFC 4648.
 depends: [
   "ocaml" {>="4.03.0"}
   "base-bytes"
-  "dune-configurator"
   "dune" {>= "2.0"}
   "bos" {with-test}
   "rresult" {with-test}

--- a/config/config.ml
+++ b/config/config.ml
@@ -1,54 +1,7 @@
-module Config = Configurator.V1
-
-let pre407 =
-  {ocaml|external unsafe_set_uint16 : bytes -> int -> int -> unit = "%caml_string_set16u" [@@noalloc]|ocaml}
-
-let standard =
-  {ocaml|external unsafe_set_uint16 : bytes -> int -> int -> unit = "%caml_bytes_set16u" [@@noalloc]|ocaml}
-
-type t = { major : int; minor : int; patch : int option; extra : string option }
-
-let v ?patch ?extra major minor = { major; minor; patch; extra }
-
-let parse s =
-  try
-    Scanf.sscanf s "%d.%d.%d+%s" (fun major minor patch extra ->
-        v ~patch ~extra major minor)
-  with End_of_file | Scanf.Scan_failure _ -> (
-    try
-      Scanf.sscanf s "%d.%d+%s" (fun major minor extra -> v ~extra major minor)
-    with End_of_file | Scanf.Scan_failure _ -> (
-      try
-        Scanf.sscanf s "%d.%d.%d" (fun major minor patch ->
-            v ~patch major minor)
-      with End_of_file | Scanf.Scan_failure _ ->
-        Scanf.sscanf s "%d.%d" (fun major minor -> v major minor)))
-
-let ( >|= ) x f = match x with Some x -> Some (f x) | None -> None
-
-let ocaml_cp ~src ~dst =
-  let ic = open_in src in
-  let oc = open_out dst in
-  let bf = Bytes.create 0x1000 in
-  let rec go () =
-    match input ic bf 0 (Bytes.length bf) with
-    | 0 -> ()
-    | len ->
-        output oc bf 0 len ;
-        go ()
-    | exception End_of_file -> () in
-  go () ;
-  close_in ic ;
-  close_out oc
+let parse s = Scanf.sscanf s "%d.%d" (fun major minor -> (major, minor))
 
 let () =
-  Config.main ~name:"config-base64" @@ fun t ->
-  match Config.ocaml_config_var t "version" >|= parse with
-  | Some version ->
-      let dst = "unsafe.ml" in
-
-      if (version.major, version.minor) >= (4, 7)
-      then ocaml_cp ~src:"unsafe_stable.ml" ~dst
-      else ocaml_cp ~src:"unsafe_pre407.ml" ~dst
-  | None -> Config.die "OCaml version is not available"
-  | exception exn -> Config.die "Got an exception: %s" (Printexc.to_string exn)
+  let version = parse Sys.ocaml_version in
+  if version >= (4, 7)
+  then print_string "unsafe_stable.ml"
+  else print_string "unsafe_pre407.ml"

--- a/config/dune
+++ b/config/dune
@@ -1,3 +1,7 @@
 (executable
- (name config)
- (libraries dune-configurator))
+ (name config))
+
+(rule
+ (with-stdout-to
+  which-unsafe-file
+  (run ./config.exe)))

--- a/src/dune
+++ b/src/dune
@@ -5,10 +5,7 @@
  (libraries bytes))
 
 (rule
- (targets unsafe.ml)
- (deps unsafe_pre407.ml unsafe_stable.ml)
- (action
-  (run ../config/config.exe)))
+ (copy %{read:../config/which-unsafe-file} unsafe.ml))
 
 (library
  (name base64_rfc2045)


### PR DESCRIPTION
Hi,

I was reviewing some uses of configurator and found that base64 uses it.

This is not necessary in this case so I'm sure you'll enjoy having one fewer dependency :)

In general, it is not necessary to use configurator to select a file depending on the OCaml version. This pattern looks like this:

- a `config.exe` program (with no dependencies) checks `Sys.ocaml_version` (`scanf` will only look at the beginning of the string, so no need to parse the patch version etc) and just outputs the name of the file to copy
- a rule links a file name to the output of `config.exe`
- a rule copies the content of that file to `unsafe.ml`

Let me know what you think!