### PR TITLE
Hide alphabet internals 

### DIFF
--- a/src/base64.ml
+++ b/src/base64.ml
@@ -57,7 +57,8 @@ let make_alphabet alphabet =
 
 let length_alphabet { emap; _ } = Array.length emap
 
-let alphabet { emap; _ } = String.init (Array.length emap) (fun i -> Char.chr emap.(i))
+let alphabet { emap; _ } =
+  String.init (Array.length emap) (fun i -> Char.chr emap.(i))
 
 let default_alphabet =
   make_alphabet

--- a/src/base64.ml
+++ b/src/base64.ml
@@ -57,7 +57,7 @@ let make_alphabet alphabet =
 
 let length_alphabet { emap; _ } = Array.length emap
 
-let alphabet { emap; _ } = emap
+let alphabet { emap; _ } = String.init (Array.length emap) (fun i -> Char.chr emap.(i))
 
 let default_alphabet =
   make_alphabet

--- a/src/base64.mli
+++ b/src/base64.mli
@@ -45,7 +45,7 @@ val make_alphabet : string -> alphabet
 val length_alphabet : alphabet -> int
 (** Returns length of the alphabet, should be 64. *)
 
-val alphabet : alphabet -> int array
+val alphabet : alphabet -> string
 (** Returns the alphabet. *)
 
 val decode_exn :

--- a/test/test.ml
+++ b/test/test.ml
@@ -184,13 +184,6 @@ let test_nocrypto () =
       Alcotest.(check (option string)) (sprintf "decode %S" input) res' res)
     nocrypto_tests
 
-let test_reynir () =
-  let r = "Hello, World!" in
-  let a = Base64.(alphabet default_alphabet) in
-  let () = Array.iteri (fun i _ -> a.(i) <- int_of_char 'A') a in
-  Alcotest.(check string) "decode encode after mutating default_alphabet"
-    r Base64.(decode_exn (encode_string r))
-
 exception Malformed
 
 exception Wrong_padding
@@ -316,7 +309,6 @@ let test_codec =
     ("Cfcs test vectors", `Quick, test_cfcs);
     ("PHP test vectors", `Quick, test_php);
     ("Nocrypto test vectors", `Quick, test_nocrypto);
-    ("Reynir test vectors", `Quick, test_reynir);
   ]
 
 let () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -184,6 +184,13 @@ let test_nocrypto () =
       Alcotest.(check (option string)) (sprintf "decode %S" input) res' res)
     nocrypto_tests
 
+let test_reynir () =
+  let r = "Hello, World!" in
+  let a = Base64.(alphabet default_alphabet) in
+  let () = Array.iteri (fun i _ -> a.(i) <- int_of_char 'A') a in
+  Alcotest.(check string) "decode encode after mutating default_alphabet"
+    r Base64.(decode_exn (encode_string r))
+
 exception Malformed
 
 exception Wrong_padding
@@ -309,6 +316,7 @@ let test_codec =
     ("Cfcs test vectors", `Quick, test_cfcs);
     ("PHP test vectors", `Quick, test_php);
     ("Nocrypto test vectors", `Quick, test_nocrypto);
+    ("Reynir test vectors", `Quick, test_reynir);
   ]
 
 let () =


### PR DESCRIPTION
`Base64.alphabet` leaks the internal `emap` array. This PR makes `Base64.alphabet` return a string instead. The following snippet shows how to break `encode |> decode` using `default_alphabet.

```OCaml
let a = Base64.(alphabet default_alphabet) in
let () = Array.iteri (fun i _ -> a.(i) <- int_of_char 'A') a in
Base64.(decode_exn (encode_string "Hello, World!"))
```

This is obviously a breaking change since the interface is altered. As an alternative, I fixed the problem by calling `Array.copy`. The code is available in my branch hide-internals2 (with a test).

I think it makes the most sense to have `Base64.alphabet` return a string. `Base64.make_alphabet` takes a string, and it's annoying for the user that the alphabet characters are returned as an `int array`.