### PR TITLE
Fix compilation on OCaml 5.0 without ocamlfind installed

### DIFF
--- a/base64.opam
+++ b/base64.opam
@@ -17,6 +17,7 @@ representation.  It is specified in RFC 4648.
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
+  "fmt" {with-test & >= "0.8.7"}
   "bos" {with-test}
   "rresult" {with-test}
   "alcotest" {with-test}

--- a/bench/benchmarks.ml
+++ b/bench/benchmarks.ml
@@ -101,7 +101,8 @@ let old_encode_and_decode len =
 
 let args = [ 0; 10; 50; 100; 500; 1000; 2500; 5000 ]
 
-let test_b64 = Bench.Test.create_indexed ~name:"Base64" ~args b64_encode_and_decode
+let test_b64 =
+  Bench.Test.create_indexed ~name:"Base64" ~args b64_encode_and_decode
 
 let test_old = Bench.Test.create_indexed ~name:"Old" ~args old_encode_and_decode
 

--- a/bench/dune
+++ b/bench/dune
@@ -1,4 +1,5 @@
 (executable
  (name benchmarks)
- (enabled_if (= %{profile} benchmark))
+ (enabled_if
+  (= %{profile} benchmark))
  (libraries base64 core_bench))

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,11 +1,13 @@
 (executable
  (name fuzz_rfc2045)
- (enabled_if (= %{profile} fuzz))
+ (enabled_if
+  (= %{profile} fuzz))
  (modules fuzz_rfc2045)
  (libraries astring crowbar fmt base64.rfc2045))
 
 (executable
  (name fuzz_rfc4648)
- (enabled_if (= %{profile} fuzz))
+ (enabled_if
+  (= %{profile} fuzz))
  (modules fuzz_rfc4648)
  (libraries astring crowbar fmt base64))

--- a/fuzz/fuzz_rfc4648.ml
+++ b/fuzz/fuzz_rfc4648.ml
@@ -82,7 +82,7 @@ let ( // ) x y =
 
 let canonic alphabet =
   let dmap = Array.make 256 (-1) in
-  String.iteri (fun i x -> dmap.(Char.code x) <- i) (Base64.alphabet alphabet);
+  String.iteri (fun i x -> dmap.(Char.code x) <- i) (Base64.alphabet alphabet) ;
   fun (input, off, len) ->
     let real_len = String.length input in
     let input_len = len in

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,7 @@
 (library
  (name base64)
  (modules unsafe base64)
- (public_name base64)
- (libraries bytes))
+ (public_name base64))
 
 (rule
  (copy %{read:../config/which-unsafe-file} unsafe.ml))
@@ -10,5 +9,4 @@
 (library
  (name base64_rfc2045)
  (modules base64_rfc2045)
- (public_name base64.rfc2045)
- (libraries bytes))
+ (public_name base64.rfc2045))

--- a/test/test.ml
+++ b/test/test.ml
@@ -269,8 +269,7 @@ let strict_base64_rfc2045_to_string x =
 let test_strict_with_malformed_input_rfc2045 =
   List.mapi
     (fun i (has, _) ->
-      Alcotest.test_case (Fmt.str "strict rfc2045 - %02d" i) `Quick
-      @@ fun () ->
+      Alcotest.test_case (Fmt.str "strict rfc2045 - %02d" i) `Quick @@ fun () ->
       try
         let _ = strict_base64_rfc2045_of_string has in
         Alcotest.failf "Strict parser valids malformed input: %S" has
@@ -280,8 +279,7 @@ let test_strict_with_malformed_input_rfc2045 =
 let test_strict_rfc2045 =
   List.mapi
     (fun i (has, expect) ->
-      Alcotest.test_case (Fmt.str "strict rfc2045 - %02d" i) `Quick
-      @@ fun () ->
+      Alcotest.test_case (Fmt.str "strict rfc2045 - %02d" i) `Quick @@ fun () ->
       try
         let res0 = strict_base64_rfc2045_of_string has in
         let res1 = strict_base64_rfc2045_to_string res0 in


### PR DESCRIPTION
```
#=== ERROR while compiling base64.3.5.0 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/base64.3.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p base64 -j 31
# exit-code            1
# env-file             ~/.opam/log/base64-19-b34c70.env
# output-file          ~/.opam/log/base64-19-b34c70.out
### output ###
# File "src/dune", line 5, characters 12-17:
# 5 |  (libraries bytes))
#                 ^^^^^
# Error: Library "bytes" not found.
# -> required by library "base64" in _build/default/src
# -> required by _build/default/META.base64
# -> required by _build/install/default/lib/base64/META
# -> required by _build/default/base64.install
# -> required by alias install
# File "src/dune", line 14, characters 12-17:
# 14 |  (libraries bytes))
#                  ^^^^^
# Error: Library "bytes" not found.
# -> required by library "base64.rfc2045" in _build/default/src
# -> required by _build/default/META.base64
# -> required by _build/install/default/lib/base64/META
# -> required by _build/default/base64.install
# -> required by alias install
```
The reason is that dune does not have the `bytes` builtin when compiling with OCaml 5.0 anymore. It might be a dune bug though but in any case it’s good to remove unnecessary dependencies which can make the compilation of base64 brittle with some combination of dune version and concurrent ocamlfind installation.